### PR TITLE
Update field-details.asciidoc

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -878,7 +878,7 @@ example: `QUERY`
 // ===============================================================
 
 | dns.question.class
-| The class of of records being queried.
+| The class of records being queried.
 
 type: keyword
 


### PR DESCRIPTION
This changeset fixes a typo in the DNS fields documentation (repeated "of").